### PR TITLE
Logging - Use LogInfo for the main sprite replacement log

### DIFF
--- a/Utils.cs
+++ b/Utils.cs
@@ -41,13 +41,13 @@ namespace SpriteReplacer
                         sprite.name = ogSprite.name;
                         spriteTexture = sprite.texture;
 
-                        Log.LogDebug("OK! Replaced: " + path);
+                        Log.LogInfo("OK! Replaced: " + path);
 
                         return true;
                     }
                     else
                     {
-                        Log.LogDebug("FAIL! No image at: " + path);
+                        Log.LogInfo("FAIL! No image at: " + path);
                     }
                 }
             }


### PR DESCRIPTION
Use LogInfo instead of LogDebug -- this means users can log which sprites have been changed (and which have not) without logging all the debug stuff (which needs to be cleaned up anyway)