### PR TITLE
Feature/cleanup

### DIFF
--- a/PatchMisc.cs
+++ b/PatchMisc.cs
@@ -24,33 +24,12 @@ namespace SpriteReplacer
             // Note: This should mean we can change names and descriptions too
             Sprite currPortrait = __instance.data.portrait;
 
-            Log.LogDebug("found portrait: " + currPortrait.name);
+            Log.LogDebug("[Misc] Portrait: " + currPortrait.name);
 
             if (currPortrait != null)
             {
                 Utils.ReplaceSpriteTexture(currPortrait);
             }
         }
-
-        /*
-        // Character Portrait
-        [HarmonyPatch(typeof(CharacterDescription), "Refresh")]
-        [HarmonyPrefix]
-        static void RefreshPrefix(ref CharacterDescription __instance)
-        {
-            Log.LogDebug("!! Replacing texture for CharacterDescription");
-            Log.LogDebug("!! Instance name=" + __instance.name);
-            Log.LogDebug("!! Instance.GameObject name=" + __instance.gameObject.name);
-
-            // Get private variable
-            // Ref: https://api.raftmodding.com/client-code-examples/untitled
-            Image currImg = Traverse.Create(__instance).Field("portrait").GetValue() as Image;
-
-            //Log.LogDebug("!!# Image.name = " + currImg.name);
-            //Log.LogDebug("!!# Image.sprite.name = " + currImg.sprite.name);
-
-            //Utils.ReplaceSpriteTexture(currImg.sprite);            
-        }
-        */
     }
 }

--- a/PatchPanels.cs
+++ b/PatchPanels.cs
@@ -17,48 +17,24 @@ namespace SpriteReplacer
         [HarmonyPrefix]
         static void StartPrefix(ref Panel __instance)
         {
-            Log.LogDebug("PANEL_LOG: START");
-
+            Log.LogDebug("[Panel] START of panel loop...");
             CanvasGroup[] canvasComponentsInChildren = __instance.GetComponentsInChildren<CanvasGroup>();
 
-            for (int i = 0; i < canvasComponentsInChildren.Length; i++)
+            for (int canvasIndex = 0; canvasIndex < canvasComponentsInChildren.Length; canvasIndex++)
             {
-                GameObject currObject = canvasComponentsInChildren[i].gameObject;
-                Log.LogDebug("PANEL:" + currObject.name);
+                GameObject currObject = canvasComponentsInChildren[canvasIndex].gameObject;
+                Log.LogDebug("[Panel] Panel name ("+ canvasIndex.ToString() +"): " + currObject.name);
+                int panelIndex = 0;
 
                 foreach (Image currImg in currObject.GetComponentsInChildren<Image>())
                 {
-                    Log.LogDebug("PANEL_Image:" + currImg.name);
-
+                    Log.LogDebug("[Panel] Panel image (" + panelIndex.ToString() + "): " + currImg.name);
                     Utils.ReplaceSpriteTexture(currImg.sprite);
-
-                    /*
-					if (currImg.sprite != null)
-					{
-						Log.LogDebug("PANEL_Image:Sprite:BASE===:" + currImg.sprite.name);
-						Texture2D spriteTexture = currImg.sprite.texture;
-						if (spriteTexture != null)
-						{
-							Log.LogDebug("PANEL_Image:Sprite:Texture:" + spriteTexture.name);
-							string path = Path.Combine(Path.GetDirectoryName(Application.dataPath), "texturemods", spriteTexture.name);
-							Log.LogDebug("SearchPath:" + path + ".png");
-							if (File.Exists(path + ".png"))
-							{
-								Sprite ogSprite = currImg.sprite;
-								ogSprite.texture.LoadImage(File.ReadAllBytes(path + ".png"));
-								Vector2 standardisedPivot = new Vector2(ogSprite.pivot.x / ogSprite.rect.width, ogSprite.pivot.y / ogSprite.rect.height);
-								Sprite sprite = Sprite.Create(ogSprite.texture, ogSprite.rect, standardisedPivot, ogSprite.pixelsPerUnit);
-								sprite.name = ogSprite.name;
-								spriteTexture = sprite.texture;
-							}
-						}
-					}
-					*/
+                    panelIndex++;
                 }
             }
-            Log.LogDebug("PANEL_LOG: END");
 
-
+            Log.LogDebug("[Panel] END of panel loop");
         }
     }
 }

--- a/PatchPools.cs
+++ b/PatchPools.cs
@@ -29,8 +29,7 @@ namespace SpriteReplacer
             {
                 GameObject GO = objectPoolItem.objectToPool;
 
-                Log.LogDebug("[SpriteReplacer:PoolHandler>Awake] Item to pool (tag1/amount/shouldExpand/tag2): " + objectPoolItem.tag + " " + objectPoolItem.amountToPool + " " + objectPoolItem.shouldExpand + " " + objectPoolItem.objectToPool.tag);
-                Log.LogDebug("[SpriteReplacer:PoolHandler>Awake] PooledItem.name: " + GO.name); // GameObject.name
+                Log.LogDebug("[Pools>Awake] Item to pool (name|tag1|amount|shouldExpand|tag2): " + GO.name + "|" + objectPoolItem.tag + "|" + objectPoolItem.amountToPool + "|" + objectPoolItem.shouldExpand + "|" + objectPoolItem.objectToPool.tag);
 
                 SpriteRenderer currSpriteRenderer = GO.GetComponent<SpriteRenderer>();
 
@@ -39,35 +38,6 @@ namespace SpriteReplacer
                     if (currSpriteRenderer.sprite != null)
                     {
                         Utils.ReplaceSpriteTexture(currSpriteRenderer.sprite);
-
-                        /*
-                        Log.LogDebug("[SpriteReplacer:PoolHandler>Awake] PooledItem.sprite.name: " + currSpriteRenderer.sprite.name);
-
-                        Texture2D spriteTexture = currSpriteRenderer.sprite.texture;
-
-                        if (spriteTexture != null)
-                        {
-                            Log.LogDebug("[SpriteReplacer:PoolHandler>Awake] PooledItem.sprite.texture.name:" + spriteTexture.name);
-
-                            string path = Path.Combine(Path.GetDirectoryName(Application.dataPath), "texturemods", spriteTexture.name);
-
-                            if (File.Exists(path + ".png"))
-                            {
-                                Log.LogInfo("[SpriteReplacer:PoolHandler>Awake] OK! Replaced (" + objectPoolItem.objectToPool.name + "|" + spriteTexture.name + "): " + path + ".png");
-
-                                Sprite ogSprite = currSpriteRenderer.sprite;
-                                ogSprite.texture.LoadImage(File.ReadAllBytes(path + ".png"));
-                                Vector2 standardisedPivot = new Vector2(ogSprite.pivot.x / ogSprite.rect.width, ogSprite.pivot.y / ogSprite.rect.height);
-                                Sprite sprite = Sprite.Create(ogSprite.texture, ogSprite.rect, standardisedPivot, ogSprite.pixelsPerUnit);
-                                sprite.name = ogSprite.name;
-                                spriteTexture = sprite.texture;
-                            }
-                            else
-                            {
-                                Log.LogError("[SpriteReplacer:PoolHandler>Awake] FAIL! No image found at: " + path + ".png");
-                            }
-                        }
-                        */
                     }
                 }
             }
@@ -79,6 +49,8 @@ namespace SpriteReplacer
         [HarmonyPrefix]
         static bool AddObjectPrefix(string tag, GameObject GO, int amt = 3, bool exp = true)
         {
+            Log.LogDebug("[Pools>AddObject] Item to pool (name|tag|amount|shouldExpand): " + GO.name + "|" + tag + "|" + amt + "|" + exp);
+
             SpriteRenderer currSpriteRenderer = GO.GetComponent<SpriteRenderer>();
 
             if (currSpriteRenderer != null)
@@ -86,35 +58,6 @@ namespace SpriteReplacer
                 if (currSpriteRenderer.sprite != null)
                 {
                     Utils.ReplaceSpriteTexture(currSpriteRenderer.sprite);
-
-                    /*
-                    Log.LogDebug("[SpriteReplacer:PoolHandler>AddObject] PooledItem.sprite.name: " + currSpriteRenderer.sprite.name);
-
-                    Texture2D spriteTexture = currSpriteRenderer.sprite.texture;
-
-                    if (spriteTexture != null)
-                    {
-                        Log.LogDebug("[SpriteReplacer:PoolHandler>AddObject] PooledItem.sprite.texture.name:" + spriteTexture.name);
-
-                        string path = Path.Combine(Path.GetDirectoryName(Application.dataPath), "texturemods", spriteTexture.name);
-
-                        if (File.Exists(path + ".png"))
-                        {
-                            Log.LogDebug("[SpriteReplacer:PoolHandler>AddObject] OK! Replaced (" + GO.name + "|" + spriteTexture.name + "): " + path + ".png");
-
-                            Sprite ogSprite = currSpriteRenderer.sprite;
-                            ogSprite.texture.LoadImage(File.ReadAllBytes(path + ".png"));
-                            Vector2 standardisedPivot = new Vector2(ogSprite.pivot.x / ogSprite.rect.width, ogSprite.pivot.y / ogSprite.rect.height);
-                            Sprite sprite = Sprite.Create(ogSprite.texture, ogSprite.rect, standardisedPivot, ogSprite.pixelsPerUnit);
-                            sprite.name = ogSprite.name;
-                            spriteTexture = sprite.texture;
-                        }
-                        else
-                        {
-                            Log.LogError("[SpriteReplacer:PoolHandler] FAIL! No image found at: " + path + ".png");
-                        }
-                    }
-                    */
                 }
             }
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -15,28 +15,28 @@ namespace SpriteReplacer
         internal static ManualLogSource Log;
 
         // Register config settings
-        public static ConfigEntry<string> configEnableTextureMods;
+        public static ConfigEntry<bool> configEnableTextureMods;
         public static ConfigEntry<string> configTextureModFolder;
-        public static ConfigEntry<string> configDebugDoPanels;
-        public static ConfigEntry<string> configDebugDoPools;
-        public static ConfigEntry<string> configDebugDoMisc;
+        public static ConfigEntry<bool> configDebugDoPanels;
+        public static ConfigEntry<bool> configDebugDoPools;
+        public static ConfigEntry<bool> configDebugDoMisc;
 
         private void Awake()
         {
             Log = base.Logger;
 
             // Config: General (args: section, key, default, description)
-            configEnableTextureMods = Config.Bind<string>("General", "EnableTextureMods", "True", "True to enable texture mods, False to completely disable them");
+            configEnableTextureMods = Config.Bind<bool>("General", "EnableTextureMods", true, "Set to true to enable texture mods, false to completely disable them");
             configTextureModFolder  = Config.Bind<string>("General", "TextureModFolder", "Vanilla", "Name of the active texture mod folder");
 
             // Config: Debug (in case you want to test specific patchers)
-            configDebugDoPanels = Config.Bind<string>("Debug", "DebugPatchPanels", "True", "Debug option. Set to False to skip patching panels (GUI, and everything in the menus before a run, including character sprites, weapons, and rune icons)");
-            configDebugDoPools  = Config.Bind<string>("Debug", "DebugPatchPools",  "True", "Debug option. Set to False to skip patching pools (most enemies and pickups)");
-            configDebugDoMisc   = Config.Bind<string>("Debug", "DebugPatchMisc",   "True", "Debug option. Set to False to skip patching misc (special cases that aren't covered by panels/pools)");
+            configDebugDoPanels = Config.Bind<bool>("xDebug", "DebugPatchPanels", true, "Debug option. Set to false to skip patching panels (GUI, and everything in the menus before a run, including character sprites, weapons, and rune icons)");
+            configDebugDoPools  = Config.Bind<bool>("xDebug", "DebugPatchPools", true, "Debug option. Set to false to skip patching pools (most enemies and pickups)");
+            configDebugDoMisc   = Config.Bind<bool>("xDebug", "DebugPatchMisc", true, "Debug option. Set to false to skip patching misc (special cases that aren't covered by panels/pools)");
 
             Log.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
 
-            bool enableMods = bool.Parse(configEnableTextureMods.Value);
+            bool enableMods = configEnableTextureMods.Value;
 
             if (!enableMods)
             {
@@ -51,9 +51,9 @@ namespace SpriteReplacer
             Log.LogInfo("Current textures folder: " + configTextureModFolder.Value);
             Log.LogInfo("Current textures path: " + currentModPath);
 
-            bool doPanels = bool.Parse(configDebugDoPanels.Value);
-            bool doPools = bool.Parse(configDebugDoPools.Value);
-            bool doMisc = bool.Parse(configDebugDoMisc.Value);
+            bool doPanels = configDebugDoPanels.Value;
+            bool doPools = configDebugDoPools.Value;
+            bool doMisc = configDebugDoMisc.Value;
 
             if (doPanels)
             {


### PR DESCRIPTION
Add "enable" config option + Remove dead code + Improve log texts:

- Config: Add a BepInEx config to enable/disable the plugin
- Config: Add BepInEx configs to replace the "doPanels/doPools/doMisc" options
- Cleanup: Tidy up debug logs, to make them more consistent and concise
- Cleanup: Remove old commented code
- Clarification: Remove the code that logs "Using Vanilla textures" instead of displaying the modded texture path
  - I've done this because "Vanilla" is a mod folder, so that text may be confusing 
  - Ie. it may suggest that the mod wasn't loading custom textures, but players might actually customise the sprites in the Vanilla folder because it's the fastest way to edit sprites (since they're provided as optional files on Nexus)
  - I've also added a proper "enable" config option to fully disable texture mods, which might have been what this change was aiming for
