### PR TITLE
Add patch for hardware cursor

### DIFF
--- a/PatchCoreInit.cs
+++ b/PatchCoreInit.cs
@@ -24,4 +24,3 @@ namespace SpriteReplacer
         }
     }
 }
-

--- a/PatchCoreInit.cs
+++ b/PatchCoreInit.cs
@@ -6,7 +6,7 @@ namespace SpriteReplacer
 {
     internal static class PatchCoreInit
     {
-        //patches Textures when initializing combat
+        //patches Textures when initializing combat (ie. the "Battle" screen)
         [HarmonyPatch(typeof(flanne.Core.InitState), "Enter")]
         [HarmonyPostfix]
         internal static void InitStatePostFix()

--- a/PatchTitleCursor.cs
+++ b/PatchTitleCursor.cs
@@ -1,0 +1,46 @@
+using HarmonyLib;
+using UnityEngine;
+using UnityEngine.UI;
+using static SpriteReplacer.SpriteReplacer;
+
+namespace SpriteReplacer
+{
+    internal static class PatchTitleCursor
+    {
+        /**
+         * Cursor Sprite Patch
+         * 
+         * Updating the cursor has to be done separately from other objects,
+         * because the cursor is initially set as a hardware cursor (in Unity
+         * via Edit > Project Settings > Player). This means it's not accessible
+         * by the FindObjectsOfTypeAll in PatchTitleInit.
+         * 
+         * Hardware cursor sprite = T_Cursor
+         * Gamepad  cursor sprite = T_CursorSprite
+         * 
+         * On the Battle screen, the gamepad cursor is always used.
+         * It's only used on the title screen if a gamepad is active.
+         * See GamepadCursor.cs: "SetActive" & "Cursor.visible"
+         */
+        [HarmonyPatch(typeof(flanne.TitleScreen.TitleScreenController), "Start")]
+        [HarmonyPrefix]
+        static void TitleScreenCursorStartPrefix(ref flanne.TitleScreen.TitleScreenController __instance)
+        {
+            GameObject cursor = __instance.gamepadCursor;
+            Image cursorImg = cursor.GetComponentInChildren<Image>();
+
+            if (cursorImg != null)
+            {
+                // Manual replacement (as this method runs before TitleScreenEnterPostfix).
+                // This is just an easy way to get the updated sprite
+                Utils.ReplaceSpriteTexture(cursorImg.sprite);
+
+                Vector2 hotspot = new Vector2(8, 8); // set in Unity via Player > Cursor Hotspot
+                Cursor.SetCursor(cursorImg.sprite.texture, hotspot, CursorMode.Auto);
+            }
+
+            // Remove this patch, as the hardware cursor image only needs to be updated once
+            hPatchTitleCursor.UnpatchSelf();
+        }
+    }
+}

--- a/PatchTitleInit.cs
+++ b/PatchTitleInit.cs
@@ -1,6 +1,5 @@
 using HarmonyLib;
 using UnityEngine;
-using UnityEngine.UI;
 using static SpriteReplacer.SpriteReplacer;
 
 namespace SpriteReplacer
@@ -21,43 +20,7 @@ namespace SpriteReplacer
                     bool result = Utils.ReplaceSpriteTexture(sprite);
                 }
             }
-
             hPatchTitleInit.UnpatchSelf();
-        }
-
-        /**
-         * Cursor Sprite Patch
-         * 
-         * Required because the cursor is initially set as a hardware cursor in
-         * Unity's player settings (so it's not accessible via FindObjectsOfTypeAll).
-         * The hardware cursor sprite is T_Cursor. 
-         * 
-         * On the Battle screen, the gamepad cursor is used instead (which uses
-         * the sprite T_CursorSprite). The gamepad cursor is also used if a
-         * gamepad is active (see GamepadCursor.cs, in particular look for
-         * "SetActive" and "Cursor.visible").
-         */
-        [HarmonyPatch(typeof(flanne.TitleScreen.TitleScreenController), "Start")]
-        [HarmonyPrefix]
-        static void TitleScreenCursorStartPrefix(ref flanne.TitleScreen.TitleScreenController __instance)
-        {
-            GameObject cursor = __instance.gamepadCursor;
-            Image cursorImg = cursor.GetComponentInChildren<Image>();
-
-            if (cursorImg != null)
-            {
-                // Manual replacement (as this method runs before TitleScreenEnterPostfix).
-                // This is just an easy way to get the updated sprite
-                Utils.ReplaceSpriteTexture(cursorImg.sprite);
-
-                // Check if the gamepad cursor is already being used; if so, we don't need to replace it
-                GameObject gamepadCursor = GameObject.Find("GamepadCursor"); // (only finds active objects)
-
-                if (gamepadCursor == null)
-                {
-                    Cursor.SetCursor(cursorImg.sprite.texture, CursorMode.Auto);
-                }
-            }
         }
     }
 }

--- a/PatchTitleInit.cs
+++ b/PatchTitleInit.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using UnityEngine;
+using UnityEngine.UI;
 using static SpriteReplacer.SpriteReplacer;
 
 namespace SpriteReplacer
@@ -20,7 +21,43 @@ namespace SpriteReplacer
                     bool result = Utils.ReplaceSpriteTexture(sprite);
                 }
             }
+
             hPatchTitleInit.UnpatchSelf();
+        }
+
+        /**
+         * Cursor Sprite Patch
+         * 
+         * Required because the cursor is initially set as a hardware cursor in
+         * Unity's player settings (so it's not accessible via FindObjectsOfTypeAll).
+         * The hardware cursor sprite is T_Cursor. 
+         * 
+         * On the Battle screen, the gamepad cursor is used instead (which uses
+         * the sprite T_CursorSprite). The gamepad cursor is also used if a
+         * gamepad is active (see GamepadCursor.cs, in particular look for
+         * "SetActive" and "Cursor.visible").
+         */
+        [HarmonyPatch(typeof(flanne.TitleScreen.TitleScreenController), "Start")]
+        [HarmonyPrefix]
+        static void TitleScreenCursorStartPrefix(ref flanne.TitleScreen.TitleScreenController __instance)
+        {
+            GameObject cursor = __instance.gamepadCursor;
+            Image cursorImg = cursor.GetComponentInChildren<Image>();
+
+            if (cursorImg != null)
+            {
+                // Manual replacement (as this method runs before TitleScreenEnterPostfix).
+                // This is just an easy way to get the updated sprite
+                Utils.ReplaceSpriteTexture(cursorImg.sprite);
+
+                // Check if the gamepad cursor is already being used; if so, we don't need to replace it
+                GameObject gamepadCursor = GameObject.Find("GamepadCursor"); // (only finds active objects)
+
+                if (gamepadCursor == null)
+                {
+                    Cursor.SetCursor(cursorImg.sprite.texture, CursorMode.Auto);
+                }
+            }
         }
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -17,6 +17,7 @@ namespace SpriteReplacer
         public static ConfigEntry<bool> configEnableTextureMods;
         public static ConfigEntry<string> configTextureModFolder;
         public static string SourceDirectory;
+        internal static Harmony hPatchTitleCursor;
         internal static Harmony hPatchTitleInit;
         internal static Harmony hPatchCoreInit;
 
@@ -47,6 +48,8 @@ namespace SpriteReplacer
 
             try
             {
+                // All these only need to run once, so we're saving them as static vars, so we can unpatch them later
+                hPatchTitleCursor = Harmony.CreateAndPatchAll(typeof(PatchTitleCursor), "PatchTitleCursor");
                 hPatchTitleInit = Harmony.CreateAndPatchAll(typeof(PatchTitleInit), "PatchTitleInit");
                 hPatchCoreInit = Harmony.CreateAndPatchAll(typeof(PatchCoreInit), "PatchCoreInit");
             }


### PR DESCRIPTION
TitleScreen: Add patch for the hardware cursor.

By default, the custom cursor that our other patches target won't show until the Battle screen.
This is because the title screen cursor is a hardware cursor, set in Unity's settings _(Edit > Project Settings > Player)_.

The comments explain what's going on (they might be a bit verbose). 

It's got a dedicated class, and uses the same unpatch approach as the other main classes, since once the hardware cursor sprite is changed, it stays that way.

---

Compiled DLL (tested with [Neon Dawn](https://www.nexusmods.com/20minutestildawn/mods/11), all working fine):

[SpriteReplacer--v17-beta4-cursor3.zip](https://github.com/ithinkandicode/20MTD-SpriteReplacer/files/8983538/SpriteReplacer--v17-beta4-cursor3.zip)
