### PR TITLE
Add music patcher + Rename to AssetReplacer

### DIFF
--- a/AssetReplacer.csproj
+++ b/AssetReplacer.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>AssetReplacer</AssemblyName>
     <Description>Replace assets in 20MTD</Description>
-    <Version>1.0.0</Version>
+    <Version>18.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>AssetReplacer</RootNamespace>

--- a/AssetReplacer.csproj
+++ b/AssetReplacer.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>SpriteReplacer</AssemblyName>
-    <Description>My first plugin</Description>
+    <AssemblyName>AssetReplacer</AssemblyName>
+    <Description>Replace assets in 20MTD</Description>
     <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
-    <RootNamespace>SpriteReplacer</RootNamespace>
+    <RootNamespace>AssetReplacer</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MusicPatchBattle.cs
+++ b/MusicPatchBattle.cs
@@ -1,0 +1,47 @@
+﻿using UnityEngine;
+using HarmonyLib;
+using flanne;
+using flanne.Core;
+using static SpriteReplacer.SpriteReplacer;
+using static SpriteReplacer.UtilsMusic;
+
+namespace SpriteReplacer
+{
+    internal class MusicPatchBattle
+    {
+        internal static string musicfilename = "battle.mp3";
+
+        [HarmonyPatch(typeof(GameController), "Start")]
+        [HarmonyPostfix]
+        internal static void TitleScreenControllerStartPostfix(ref GameController __instance)
+        {
+            initMusicPatch(__instance);
+        }
+
+        // Async due to waiting for the music file to load
+        internal static async void initMusicPatch(GameController controllerInstance)
+        {
+            Log.LogDebug($"[Music] Attempting to load custom music ({musicfilename})...");
+
+            AudioClip customAudioClip = await LoadMusicFromDisk(musicfilename, AudioType.MPEG);
+
+            if (customAudioClip == null)
+            {
+                Log.LogError($"[Music] Failed. Could not load the music track ({musicfilename})");
+                return;
+            }
+
+            Log.LogDebug("[Music] Success. Applying custom music track!");
+
+            // Update the music.
+            // This won't have an immediate effect, we need to stop the
+            // original music from playing first
+            controllerInstance.battleMusic = customAudioClip;
+
+            AudioManager.Instance.FadeOutMusic(1f);
+            AudioManager.Instance.PlayMusic(controllerInstance.battleMusic);
+            //AudioManager.Instance.PlayMusic(modMusicClip); // also works
+            AudioManager.Instance.FadeInMusic(1f);
+        }
+    }
+}

--- a/MusicPatchBattle.cs
+++ b/MusicPatchBattle.cs
@@ -2,10 +2,10 @@
 using HarmonyLib;
 using flanne;
 using flanne.Core;
-using static SpriteReplacer.SpriteReplacer;
-using static SpriteReplacer.UtilsMusic;
+using static AssetReplacer.AssetReplacer;
+using static AssetReplacer.UtilsMusic;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     internal class MusicPatchBattle
     {

--- a/MusicPatchTitle.cs
+++ b/MusicPatchTitle.cs
@@ -1,0 +1,47 @@
+﻿using UnityEngine;
+using HarmonyLib;
+using flanne;
+using flanne.TitleScreen;
+using static SpriteReplacer.SpriteReplacer;
+using static SpriteReplacer.UtilsMusic;
+
+namespace SpriteReplacer
+{
+    internal class MusicPatchTitle
+    {
+        internal static string musicfilename = "title.mp3";
+
+        [HarmonyPatch(typeof(TitleScreenController), "Start")]
+        [HarmonyPostfix]
+        internal static void TitleScreenControllerStartPostfix(ref TitleScreenController __instance)
+        {
+            initMusicPatch(__instance);
+        }
+
+        // Async due to waiting for the music file to load
+        internal static async void initMusicPatch(TitleScreenController controllerInstance)
+        {
+            Log.LogDebug($"[Music] Attempting to load custom music ({musicfilename})...");
+
+            AudioClip customAudioClip = await LoadMusicFromDisk(musicfilename, AudioType.MPEG);
+
+            if (customAudioClip == null)
+            {
+                Log.LogError($"[Music] Failed. Could not load the music track ({musicfilename})");
+                return;
+            }
+
+            Log.LogDebug("[Music] Success. Applying custom music track!");
+
+            // Update the music.
+            // This won't have an immediate effect, we need to stop the
+            // original music from playing first
+            controllerInstance.titleScreenMusic = customAudioClip;
+
+            AudioManager.Instance.FadeOutMusic(1f);
+            AudioManager.Instance.PlayMusic(controllerInstance.titleScreenMusic);
+            //AudioManager.Instance.PlayMusic(modMusicClip); // also works
+            AudioManager.Instance.FadeInMusic(1f);
+        }
+    }
+}

--- a/MusicPatchTitle.cs
+++ b/MusicPatchTitle.cs
@@ -2,10 +2,10 @@
 using HarmonyLib;
 using flanne;
 using flanne.TitleScreen;
-using static SpriteReplacer.SpriteReplacer;
-using static SpriteReplacer.UtilsMusic;
+using static AssetReplacer.AssetReplacer;
+using static AssetReplacer.UtilsMusic;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     internal class MusicPatchTitle
     {

--- a/PatchCoreInit.cs
+++ b/PatchCoreInit.cs
@@ -1,8 +1,8 @@
 using HarmonyLib;
 using UnityEngine;
-using static SpriteReplacer.SpriteReplacer;
+using static AssetReplacer.AssetReplacer;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     internal static class PatchCoreInit
     {

--- a/PatchTitleCursor.cs
+++ b/PatchTitleCursor.cs
@@ -1,9 +1,9 @@
 using HarmonyLib;
 using UnityEngine;
 using UnityEngine.UI;
-using static SpriteReplacer.SpriteReplacer;
+using static AssetReplacer.AssetReplacer;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     internal static class PatchTitleCursor
     {

--- a/PatchTitleInit.cs
+++ b/PatchTitleInit.cs
@@ -1,8 +1,8 @@
 using HarmonyLib;
 using UnityEngine;
-using static SpriteReplacer.SpriteReplacer;
+using static AssetReplacer.AssetReplacer;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     internal static class PatchTitleInit
     {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -6,10 +6,10 @@ using System.IO;
 using UnityEngine;
 using HarmonyLib;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
-    public class SpriteReplacer : BaseUnityPlugin
+    public class AssetReplacer : BaseUnityPlugin
     {
         internal static ManualLogSource Log;
 
@@ -42,7 +42,7 @@ namespace SpriteReplacer
 
             if (!enableAllMods)
             {
-                Log.LogInfo("All mods are disabled in the config (BepInEx\\config\\SpriteReplacer.cfg). No game assets will be replaced");
+                Log.LogInfo("All mods are disabled in the config (BepInEx\\config\\AssetReplacer.cfg). No game assets will be replaced");
                 return;
             }
 
@@ -60,7 +60,7 @@ namespace SpriteReplacer
 
             if (!enableMods)
             {
-                Log.LogInfo("Texture mods are disabled in the config (BepInEx\\config\\SpriteReplacer.cfg). Default game textures will be used");
+                Log.LogInfo("Texture mods are disabled in the config (BepInEx\\config\\AssetReplacer.cfg). Default game textures will be used");
                 return;
             }
 
@@ -89,7 +89,7 @@ namespace SpriteReplacer
 
             if (!enableMods)
             {
-                Log.LogInfo("Music mods are disabled in the config (BepInEx\\config\\SpriteReplacer.cfg). Default game music will be used");
+                Log.LogInfo("Music mods are disabled in the config (BepInEx\\config\\AssetReplacer.cfg). Default game music will be used");
                 return;
             }
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -14,7 +14,9 @@ namespace SpriteReplacer
         internal static ManualLogSource Log;
 
         // Register config settings
+        public static ConfigEntry<bool> configEnableAllMods;
         public static ConfigEntry<bool> configEnableTextureMods;
+        public static ConfigEntry<bool> configEnableMusicMods;
         public static ConfigEntry<string> configTextureModFolder;
         public static ConfigEntry<string> configMusicModFolder;
         public static string SourceSpritesDirectory;
@@ -27,12 +29,22 @@ namespace SpriteReplacer
         {
             Log = base.Logger;
 
-            // Config: General (args: section, key, default, description)
+            // Configs (args: section, key, default, description)
+            configEnableAllMods = Config.Bind<bool>("All", "EnableAll", true, "Set to true to enable all mods, false to completely disable them");
             configEnableTextureMods = Config.Bind<bool>("General", "EnableTextureMods", true, "Set to true to enable texture mods, false to completely disable them");
             configTextureModFolder = Config.Bind<string>("General", "TextureModFolder", "Vanilla", "Name of the active texture mod folder");
+            configEnableMusicMods = Config.Bind<bool>("General", "EnableMusicMods", true, "Set to true to enable music mods, false to completely disable them");
             configMusicModFolder = Config.Bind<string>("General", "MusicModFolder", "Demo", "Name of the active music mod folder");
 
             Log.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
+
+            bool enableAllMods = configEnableAllMods.Value;
+
+            if (!enableAllMods)
+            {
+                Log.LogInfo("All mods are disabled in the config (BepInEx\\config\\SpriteReplacer.cfg). No game assets will be replaced");
+                return;
+            }
 
             // Setup all directory vars
             SourceSpritesDirectory = Path.Combine(Path.GetDirectoryName(Application.dataPath), "Mods", "Textures", configTextureModFolder.Value);
@@ -73,6 +85,14 @@ namespace SpriteReplacer
 
         private void patchMusic()
         {
+            bool enableMods = configEnableMusicMods.Value;
+
+            if (!enableMods)
+            {
+                Log.LogInfo("Music mods are disabled in the config (BepInEx\\config\\SpriteReplacer.cfg). Default game music will be used");
+                return;
+            }
+
             try
             {
                 Harmony.CreateAndPatchAll(typeof(MusicPatchTitle), "MusicPatch");

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -31,10 +31,10 @@ namespace SpriteReplacer
 
             // Configs (args: section, key, default, description)
             configEnableAllMods = Config.Bind<bool>("All", "EnableAll", true, "Set to true to enable all mods, false to completely disable them");
-            configEnableTextureMods = Config.Bind<bool>("General", "EnableTextureMods", true, "Set to true to enable texture mods, false to completely disable them");
-            configTextureModFolder = Config.Bind<string>("General", "TextureModFolder", "Vanilla", "Name of the active texture mod folder");
-            configEnableMusicMods = Config.Bind<bool>("General", "EnableMusicMods", true, "Set to true to enable music mods, false to completely disable them");
-            configMusicModFolder = Config.Bind<string>("General", "MusicModFolder", "Demo", "Name of the active music mod folder");
+            configEnableTextureMods = Config.Bind<bool>("Textures", "EnableTextureMods", true, "Set to true to enable texture mods, false to completely disable them");
+            configTextureModFolder = Config.Bind<string>("Textures", "TextureModFolder", "Vanilla", "Name of the active texture mod folder");
+            configEnableMusicMods = Config.Bind<bool>("Music", "EnableMusicMods", true, "Set to true to enable music mods, false to completely disable them");
+            configMusicModFolder = Config.Bind<string>("Music", "MusicModFolder", "Demo", "Name of the active music mod folder");
 
             Log.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -16,7 +16,9 @@ namespace SpriteReplacer
         // Register config settings
         public static ConfigEntry<bool> configEnableTextureMods;
         public static ConfigEntry<string> configTextureModFolder;
-        public static string SourceDirectory;
+        public static ConfigEntry<string> configMusicModFolder;
+        public static string SourceSpritesDirectory;
+        public static string SourceMusicDirectory;
         internal static Harmony hPatchTitleCursor;
         internal static Harmony hPatchTitleInit;
         internal static Harmony hPatchCoreInit;
@@ -28,9 +30,20 @@ namespace SpriteReplacer
             // Config: General (args: section, key, default, description)
             configEnableTextureMods = Config.Bind<bool>("General", "EnableTextureMods", true, "Set to true to enable texture mods, false to completely disable them");
             configTextureModFolder = Config.Bind<string>("General", "TextureModFolder", "Vanilla", "Name of the active texture mod folder");
+            configMusicModFolder = Config.Bind<string>("General", "MusicModFolder", "Demo", "Name of the active music mod folder");
 
             Log.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
 
+            // Setup all directory vars
+            SourceSpritesDirectory = Path.Combine(Path.GetDirectoryName(Application.dataPath), "Mods", "Textures", configTextureModFolder.Value);
+            SourceMusicDirectory = Path.Combine(Path.GetDirectoryName(Application.dataPath), "Mods", "Music", configMusicModFolder.Value);
+
+            this.patchSprites();
+            this.patchMusic();
+        }
+
+        private void patchSprites()
+        {
             bool enableMods = configEnableTextureMods.Value;
 
             if (!enableMods)
@@ -39,10 +52,8 @@ namespace SpriteReplacer
                 return;
             }
 
-            SourceDirectory = Path.Combine(Path.GetDirectoryName(Application.dataPath), "Mods", "Textures", configTextureModFolder.Value);
-
             Log.LogInfo("Current textures folder: " + configTextureModFolder.Value);
-            Log.LogInfo("Current textures path: " + SourceDirectory);
+            Log.LogInfo("Current textures path: " + SourceSpritesDirectory);
 
             SpriteInfo.Init();
 
@@ -56,7 +67,21 @@ namespace SpriteReplacer
             catch (Exception e)
             {
                 Log.LogError(e.Message);
-                Log.LogError($"{PluginInfo.PLUGIN_GUID} failed to patch methods.");
+                Log.LogError($"{PluginInfo.PLUGIN_GUID} failed to patch texture methods.");
+            }
+        }
+
+        private void patchMusic()
+        {
+            try
+            {
+                Harmony.CreateAndPatchAll(typeof(MusicPatchTitle), "MusicPatch");
+                Harmony.CreateAndPatchAll(typeof(MusicPatchBattle), "MusicPatchBattle");
+            }
+            catch (Exception e)
+            {
+                Log.LogError(e.Message);
+                Log.LogError($"{PluginInfo.PLUGIN_GUID} failed to patch music methods.");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Can currently replace:
 
 Code starts at Plugin.cs, the texture replace code is in Utils.cs.
 
-Credit to [BugFables-AssetsRedirector](https://github.com/aldelaro5/BugFables-AssetsRedirector), the code to make a replacement texture comes from their repo ([here](https://github.com/aldelaro5/BugFables-AssetsRedirector/blob/1.0.0/AssetsRedirection.cs#L81)).
-
 ## Usage
 
 1. Install BepInEx
@@ -42,3 +40,9 @@ Credit to [BugFables-AssetsRedirector](https://github.com/aldelaro5/BugFables-As
 - [Wiki » Modding](https://minutes-till-dawn.fandom.com/wiki/Modding)
 - [BepInEx Github](https://github.com/BepInEx/BepInEx/releases)
 - [BepInEx Docs](https://docs.bepinex.dev/index.html)
+
+
+## Credits
+
+- [aldelaro5/BugFables-AssetsRedirector](https://github.com/aldelaro5/BugFables-AssetsRedirector/blob/1.0.0/AssetsRedirection.cs#L81) - Code to make a replacement texture
+- [TormentedEmu/7DTD-A19-DMTMods](https://github.com/TormentedEmu/7DTD-A19-DMTMods/blob/master/TE_MenuMusic/Harmony/Harmony.cs) - Code for the music loader

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# 20MTD SpriteReplacer
-BepInEx plugin to replace sprites (textures) in 20 Minutes Till Dawn.
+# 20MTD AssetReplacer
+BepInEx plugin to replace assets in 20 Minutes Till Dawn.
+
+Can currently replace:
+
+- Sprites (textures)
+- Music
 
 Code starts at Plugin.cs, the texture replace code is in Utils.cs.
 

--- a/SpriteHelper/SpriteInfo.cs
+++ b/SpriteHelper/SpriteInfo.cs
@@ -3,9 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
-using static SpriteReplacer.SpriteReplacer;
+using static AssetReplacer.AssetReplacer;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     public static class SpriteInfo
     {

--- a/SpriteHelper/SpriteInfo.cs
+++ b/SpriteHelper/SpriteInfo.cs
@@ -13,9 +13,10 @@ namespace SpriteReplacer
 
         internal static void Init()
         {
-            foreach (string filepath in Directory.EnumerateFiles(SourceDirectory, "*.*", SearchOption.AllDirectories).Select(filepath => filepath.Replace(SourceDirectory + "\\", "")))
+            foreach (string filepath in Directory.EnumerateFiles(SourceSpritesDirectory, "*.*", SearchOption.AllDirectories).Select(filepath => filepath.Replace(SourceSpritesDirectory + "\\", "")))
             {
-                Log.LogDebug("Found file " + Path.GetFileNameWithoutExtension(filepath) + " at " + filepath);
+                //@todo: Uncomment this
+                //Log.LogDebug("Found file " + Path.GetFileNameWithoutExtension(filepath) + " at " + filepath);
                 SpriteDict.Add(Path.GetFileNameWithoutExtension(filepath), filepath);
             }
         }

--- a/SpriteHelper/SpriteStore.cs
+++ b/SpriteHelper/SpriteStore.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using UnityEngine;
-using static SpriteReplacer.SpriteReplacer;
+using static AssetReplacer.AssetReplacer;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     public static class SpriteStore
     {

--- a/SpriteReplacer.sln
+++ b/SpriteReplacer.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31515.178
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpriteReplacer", "SpriteReplacer.csproj", "{27211C80-2E46-4F38-A8B8-05B0F1E3A237}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssetReplacer", "AssetReplacer.csproj", "{27211C80-2E46-4F38-A8B8-05B0F1E3A237}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Utils.cs
+++ b/Utils.cs
@@ -17,7 +17,7 @@ namespace SpriteReplacer
 
                 if (spriteTexture != null)
                 {
-                    string path = Path.Combine(SourceDirectory, SpriteInfo.GetFilePath(spriteTexture.name));
+                    string path = Path.Combine(SourceSpritesDirectory, SpriteInfo.GetFilePath(spriteTexture.name));
 
                     //Log.LogDebug("Sprite.Texture.name:" + spriteTexture.name);
                     //Log.LogDebug("SearchPath:" + path);
@@ -31,7 +31,8 @@ namespace SpriteReplacer
                         sprite.name = ogSprite.name;
                         spriteTexture = sprite.texture;
 
-                        Log.LogDebug("OK! Replaced: " + path);
+                        //@todo: uncomment this
+                        //Log.LogDebug("OK! Replaced: " + path);
 
                         SpriteStore.ChangedSprites.Add(targetSprite);
 
@@ -39,7 +40,8 @@ namespace SpriteReplacer
                     }
                     else
                     {
-                        Log.LogDebug("FAIL! No Texture available for " + spriteTexture.name);
+                        //@todo: uncomment this
+                        //Log.LogDebug("FAIL! No Texture available for " + spriteTexture.name);
                     }
                 }
             }

--- a/Utils.cs
+++ b/Utils.cs
@@ -1,8 +1,8 @@
 ﻿using System.IO;
 using UnityEngine;
-using static SpriteReplacer.SpriteReplacer;
+using static AssetReplacer.AssetReplacer;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     internal class Utils
     {

--- a/UtilsMusic.cs
+++ b/UtilsMusic.cs
@@ -3,9 +3,9 @@ using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
-using static SpriteReplacer.SpriteReplacer;
+using static AssetReplacer.AssetReplacer;
 
-namespace SpriteReplacer
+namespace AssetReplacer
 {
     /**
      * References » Unity:

--- a/UtilsMusic.cs
+++ b/UtilsMusic.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+using static SpriteReplacer.SpriteReplacer;
+
+namespace SpriteReplacer
+{
+    /**
+     * References » Unity:
+     *   https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Networking.UnityWebRequest.html
+     *   https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Networking.UnityWebRequestMultimedia.GetAudioClip.html
+     * 
+     * Vanilla music filenames:
+     *   Title  = "Pretty Dungeon LOOP.ogg"   (mod target filename: "title.mp3")
+     *   Battle = "Wasteland Combat Loop.ogg" (mod target filename: "battle.mp3")
+     */
+    class UtilsMusic
+    {
+        /**
+         * Asynchronously load a music track
+         * 
+         * Example: await LoadMusicFromDisk("title", AudioType.MPEG);
+         * Available audio types: https://docs.unity3d.com/2019.4/Documentation/ScriptReference/AudioType.html
+         * Based heavily on: https://github.com/TormentedEmu/7DTD-A19-DMTMods/blob/master/TE_MenuMusic/Harmony/Harmony.cs
+         */
+        public static async Task<AudioClip> LoadMusicFromDisk(string musicFilename, AudioType audioType)
+        {
+            AudioClip audioClip = null;
+            string musicPath = Path.Combine("file:///", SourceMusicDirectory, musicFilename);
+
+            Log.LogInfo($"Loading music (title.mp3) from: {musicPath}");
+
+            using (UnityWebRequest webRequest = UnityWebRequestMultimedia.GetAudioClip(musicPath, audioType))
+            {
+                webRequest.SendWebRequest();
+
+                try
+                {
+                    while (!webRequest.isDone)
+                    {
+                        await Task.Delay(5);
+                    }
+
+                    if (webRequest.isNetworkError || webRequest.isHttpError)
+                    {
+                        Log.LogDebug(webRequest.error);
+                        Log.LogDebug("Music file retrieval failed (network error)");
+                    }
+                    else
+                    {
+                        audioClip = DownloadHandlerAudioClip.GetContent(webRequest);
+                        audioClip.name = "customMusic" + musicFilename;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.LogError(e.Message);
+                    Log.LogError("Failed to retrieve music file (general error).");
+                }
+            }
+
+            return audioClip;
+        }
+    }
+}


### PR DESCRIPTION
- Add patchers for the title + battle music.
- Rename project to "AssetReplacer"
- Re-work Plugin.cs and generic "mod" variables names to account for the new music patchers
  - Eg. `SourceDirectory` is now `SourceSpritesDirectory`.
- Bump version to 18.0.0

**todo:**

- Update sprite logging to include the prefix `[Sprites]`, similar to how the music patchers prefix its logs with `[Music]`