### PR TITLE
Dynamically change the fog of war color

### DIFF
--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -18,6 +18,8 @@ namespace AssetReplacer
         public static ConfigEntry<bool> ConfigEnableMusicMods;
         public static ConfigEntry<string> ConfigTextureModFolders;
         public static ConfigEntry<string> ConfigMusicModFolders;
+        public static ConfigEntry<bool> ConfigTextureDynamicFogOfWar;
+
         internal static Harmony hPatchTitleCursor;
         internal static Harmony hPatchTitleStart;
         internal static Harmony hPatchBattleStart;
@@ -45,6 +47,12 @@ namespace AssetReplacer
             Example:
                 TextureMod1,TextureMod2,TextureMod3
             TextureMod3 overwrites the textures of TextureMod2 which overwrites the textures of TextureMod1");
+
+            ConfigTextureDynamicFogOfWar = Config.Bind<bool>(
+                "Textures",
+                "EnableDynamicFogOfWarColor",
+                true,
+                "Set to true to dynamically change the fog of war color based on the ground tile texture, false to disable.");
 
             Log.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
 

--- a/src/patches/PatchBattleStart.cs
+++ b/src/patches/PatchBattleStart.cs
@@ -1,5 +1,10 @@
 using HarmonyLib;
 using UnityEngine;
+using UnityEngine.UI;
+
+using flanne;
+
+using AssetReplacer.AssetStore;
 
 namespace AssetReplacer.Patch
 {
@@ -16,6 +21,50 @@ namespace AssetReplacer.Patch
                 foreach (Sprite sprite in sprites)
                 {
                     Utils.TryReplaceTexture2D(sprite);
+                }
+
+                if(AssetReplacer.ConfigTextureDynamicFogOfWar.Value)
+                {
+                    Transform fogOfWarCanvas = PlayerController.Instance.transform.Find("FogOfWarCanvas");
+
+                    if(fogOfWarCanvas != null)
+                    {
+                        Transform child = fogOfWarCanvas.GetChild(0);
+
+                        if(child == null)
+                        {
+                            Debug.LogError("Fog of war canvas has no child!");
+                            return;
+                        }
+
+                        RawImage img = child.GetComponent<RawImage>();
+
+                        if(img == null)
+                        {
+                            Debug.LogError("Fog of war image has no RawImage component!");
+                            return;
+                        }
+
+                        Texture2D grasstile = null;
+                        if(!TextureStore.textureDict.TryGetValue("T_TileGrass", out grasstile))
+                            return;
+
+                        Color[] colors = grasstile.GetPixels();
+
+                        Color additive = Color.black;
+
+                        foreach(Color color in colors)
+                        {
+                            additive += color;
+                        }
+
+                        Color average = additive / colors.Length * 0.75f;
+
+                        Material material = img.material;
+                        material.color = average;
+                    }
+                    else
+                        Debug.LogError("Unable to find fog of war canvas!");
                 }
             }
         }


### PR DESCRIPTION
This calculates the new fog of war color based on the average color of the grass texture.  
This should probably be extended to other maps, but I don't have those unlocked.  
For now players can just disable the dynamic fog of war if they play in a different map.